### PR TITLE
fix: api reference ids weren't being computed correctly

### DIFF
--- a/src/__test__/db/db.test.ts
+++ b/src/__test__/db/db.test.ts
@@ -126,7 +126,17 @@ it("definition register", async () => {
     );
 });
 
-const DOCS_REGISTER_DEFINITION: FernRegistry.docs.v1.write.DocsDefinition = {
+const WRITE_DOCS_REGISTER_DEFINITION: FernRegistry.docs.v1.write.DocsDefinition = {
+    pages: {},
+    config: {
+        navigation: {
+            items: [],
+        },
+    },
+};
+
+const READ_DOCS_REGISTER_DEFINITION: FernRegistry.docs.v1.read.DocsDefinition = {
+    apis: {},
     pages: {},
     config: {
         navigation: {
@@ -138,18 +148,18 @@ const DOCS_REGISTER_DEFINITION: FernRegistry.docs.v1.write.DocsDefinition = {
 it("docs register", async () => {
     // register docs
     await CLIENT.docs.v1.write.registerDocs({
-        docsDefinition: DOCS_REGISTER_DEFINITION,
+        docsDefinition: WRITE_DOCS_REGISTER_DEFINITION,
         orgId: "fern",
         domain: "docs.fern.com",
     });
     // load docs
     const docs = await CLIENT.docs.v1.read.getDocsForDomain("docs.fern.com");
     // assert docs are equal
-    expect(JSON.stringify(docs)).toEqual(JSON.stringify(DOCS_REGISTER_DEFINITION));
+    expect(docs).toEqual(READ_DOCS_REGISTER_DEFINITION);
 
     //re-register docs
     await CLIENT.docs.v1.write.registerDocs({
-        docsDefinition: DOCS_REGISTER_DEFINITION,
+        docsDefinition: WRITE_DOCS_REGISTER_DEFINITION,
         orgId: "fern",
         domain: "docs.fern.com",
     });

--- a/src/__test__/testTransformDocsDefinitionToDb.test.ts
+++ b/src/__test__/testTransformDocsDefinitionToDb.test.ts
@@ -1,0 +1,17 @@
+import * as FernRegistryDocsRead from "../generated/api/resources/docs/resources/v1/resources/read";
+import { getReferencedApiDefinitionIds } from "../services/transformDocsDefinitionToDb";
+
+it("definition register", async () => {
+    const navigationConfig: FernRegistryDocsRead.NavigationConfig = {
+        items: [
+            {
+                type: "api",
+                title: "API Reference",
+                api: "123405930",
+                urlSlug: "myUrl",
+            },
+        ],
+    };
+    const referencedApiDefinitionIds = getReferencedApiDefinitionIds(navigationConfig);
+    expect(referencedApiDefinitionIds).toEqual(["123405930"]);
+});

--- a/src/services/transformDocsDefinitionToDb.ts
+++ b/src/services/transformDocsDefinitionToDb.ts
@@ -46,7 +46,7 @@ export function transformNavigationItemForReading(
     }
 }
 
-function getReferencedApiDefinitionIds(
+export function getReferencedApiDefinitionIds(
     navigationConfig: FernRegistryDocsRead.NavigationConfig
 ): FernRegistry.ApiDefinitionId[] {
     return navigationConfig.items.flatMap((item) => getReferencedApiDefinitionIdFromItem(item));
@@ -57,7 +57,7 @@ function getReferencedApiDefinitionIdFromItem(
 ): FernRegistry.ApiDefinitionId[] {
     switch (item.type) {
         case "api":
-            return [...item.api];
+            return [item.api];
         case "page":
             return [];
         case "section":


### PR DESCRIPTION
spread operator was being unintentionally used on a string